### PR TITLE
Add liveEvent & liveEventParticipant backend support with join-code, ADM bypass, title uniqueness and location validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,3 +302,11 @@ Canonical backend entities used by the Apps Script backend and sync contract:
 - `report`
 
 `hostMembership` supports many accounts managing one host without creating duplicate host map pins. Approved memberships all render the same host profile in the workspace; only `new_host` approvals create a new host location entry. ADM authority is enforced with a server-side allowlist in Apps Script (`google-sheets-backend.gs`).
+
+### Live event backend contract
+
+Live event collaboration is persisted with two canonical backend resources. `liveEvent` rows use only these canonical fields for the event itself: `id`, `title`, `titleBase`, `description`, `status`, `joinCode`, `createdByAccountId`, `createdByHostId`, `startedAt`, `endedAt`, and `filters`. Active live event titles are unique; when a new active event reuses an active title, the backend assigns the next available suffix such as `Title (2)` or `Title (3)` and returns the assigned `title` to the UI.
+
+`liveEventParticipant` rows use these canonical fields: `liveEventId`, `hostId`, `accountId`, `isLead`, `joinedAt`, `lastLocationAt`, `speedKmh`, and `isSharingEnabled`. Hosts join active live events with `joinCode`; ADMs can join any active live event without a code. Location publishing must always be validated by the backend: the publishing account must be an active member of the host, unless the account is an ADM.
+
+While Apps Script remains the temporary backend, `src/services/google-sheets-backend.gs` owns resource resolution for both `liveEvents` and `liveEventParticipants`, plus the `createLiveEvent`, `joinLiveEvent`, and `publishLiveEventParticipantLocation` actions. The web adapter in `src/services/repository.js` mirrors those operations locally for offline fallback and sends the same actions to Apps Script when a sync URL is configured.

--- a/src/services/google-sheets-backend.gs
+++ b/src/services/google-sheets-backend.gs
@@ -28,6 +28,16 @@ const RESOURCE_CONFIG = {
     sheetName: 'hostRequests',
     resourceAliases: ['hostrequest', 'hostrequests', 'title request', 'title requests', 'titlerequest', 'titlerequests'],
     sheetAliases: ['hostrequest', 'hostrequests', 'title request', 'title requests', 'titlerequest', 'titlerequests']
+  },
+  liveEvents: {
+    sheetName: 'liveEvents',
+    resourceAliases: ['liveevent', 'liveevents', 'live event', 'live events'],
+    sheetAliases: ['liveevent', 'liveevents', 'live event', 'live events']
+  },
+  liveEventParticipants: {
+    sheetName: 'liveEventParticipants',
+    resourceAliases: ['liveeventparticipant', 'liveeventparticipants', 'live event participant', 'live event participants'],
+    sheetAliases: ['liveeventparticipant', 'liveeventparticipants', 'live event participant', 'live event participants']
   }
 };
 
@@ -115,6 +125,9 @@ function doPost(e) {
     const body = JSON.parse(e.postData.contents);
     if (body.action === 'verifySession') return createResponse(handleVerifySession(body));
     if (body.action === 'exchangeHostAccessCode') return createResponse(handleExchangeHostAccessCode(body));
+    if (body.action === 'createLiveEvent') return createResponse(handleCreateLiveEvent(body));
+    if (body.action === 'joinLiveEvent') return createResponse(handleJoinLiveEvent(body));
+    if (body.action === 'publishLiveEventParticipantLocation') return createResponse(handlePublishLiveEventParticipantLocation(body));
     const resolved = resolveSheet(body.resource, SpreadsheetApp.getActiveSpreadsheet());
     if (!resolved) return createResponse({ error: 'Resource not found' });
     resolved.sheet.getRange(2, 1).setValue(JSON.stringify(body.payload));
@@ -147,6 +160,110 @@ function handleExchangeHostAccessCode(body) {
   membership.sessionIssuedAt = new Date().toISOString();
   writeResourceList('hostMemberships', memberships);
   return { valid: true, token, accountId: membership.accountId, hostMembership: membership };
+}
+
+
+function normalizeLiveEvent(entry) {
+  const now = new Date().toISOString();
+  const titleBase = String(entry && (entry.titleBase || entry.title) || '').trim() || 'Live Event';
+  return {
+    id: entry && entry.id || Utilities.getUuid(),
+    title: String(entry && entry.title || titleBase).trim(),
+    titleBase: titleBase,
+    description: String(entry && entry.description || ''),
+    status: entry && entry.status || 'active',
+    joinCode: String(entry && entry.joinCode || '').trim(),
+    createdByAccountId: String(entry && entry.createdByAccountId || ''),
+    createdByHostId: String(entry && entry.createdByHostId || ''),
+    startedAt: entry && entry.startedAt || now,
+    endedAt: entry && entry.endedAt || '',
+    filters: entry && entry.filters && typeof entry.filters === 'object' ? entry.filters : {}
+  };
+}
+
+function normalizeLiveEventParticipant(entry) {
+  return {
+    liveEventId: String(entry && entry.liveEventId || ''),
+    hostId: String(entry && entry.hostId || ''),
+    accountId: String(entry && entry.accountId || ''),
+    isLead: Boolean(entry && entry.isLead),
+    joinedAt: entry && entry.joinedAt || new Date().toISOString(),
+    lastLocationAt: entry && entry.lastLocationAt || '',
+    speedKmh: Number(entry && entry.speedKmh) || 0,
+    isSharingEnabled: !(entry && entry.isSharingEnabled === false)
+  };
+}
+
+function resolveUniqueLiveEventTitle(titleBase, liveEvents, currentId) {
+  const normalizedBase = String(titleBase || '').trim() || 'Live Event';
+  const activeTitles = (liveEvents || [])
+    .filter(function(event) { return event.status === 'active' && event.id !== currentId; })
+    .map(function(event) { return String(event.title || '').trim().toLowerCase(); });
+  let candidate = normalizedBase;
+  let suffix = 2;
+  while (activeTitles.indexOf(candidate.toLowerCase()) >= 0) {
+    candidate = normalizedBase + ' (' + suffix + ')';
+    suffix += 1;
+  }
+  return candidate;
+}
+
+function isAdmAccount(accountId) {
+  const accounts = readResourceList('accounts');
+  const account = accounts.find(function(item) { return item.id === accountId; });
+  return Boolean(account && ADM_ALLOWLIST.indexOf(String(account.email || '').toLowerCase()) >= 0);
+}
+
+function isActiveHostMember(accountId, hostId) {
+  const memberships = readResourceList('hostMemberships');
+  return memberships.some(function(item) {
+    return item.accountId === accountId && item.hostId === hostId && item.status !== 'revoked';
+  });
+}
+
+function handleCreateLiveEvent(body) {
+  const liveEvents = readResourceList('liveEvents').map(normalizeLiveEvent);
+  const liveEvent = normalizeLiveEvent(body.liveEvent || {});
+  liveEvent.titleBase = liveEvent.titleBase || liveEvent.title;
+  liveEvent.title = resolveUniqueLiveEventTitle(liveEvent.titleBase, liveEvents, liveEvent.id);
+  liveEvents.push(liveEvent);
+  writeResourceList('liveEvents', liveEvents);
+  return { success: true, liveEvent: liveEvent };
+}
+
+function handleJoinLiveEvent(body) {
+  const liveEvents = readResourceList('liveEvents').map(normalizeLiveEvent);
+  const liveEvent = liveEvents.find(function(event) { return event.id === body.liveEventId && event.status === 'active'; });
+  if (!liveEvent) return { error: 'Live event not found' };
+  const adm = Boolean(body.isAdm) || isAdmAccount(String(body.accountId || ''));
+  if (!adm && liveEvent.joinCode !== String(body.joinCode || '').trim()) return { error: 'Invalid join code' };
+  if (!adm && !isActiveHostMember(String(body.accountId || ''), String(body.hostId || ''))) return { error: 'Only host members can join for this host' };
+  const participants = readResourceList('liveEventParticipants').map(normalizeLiveEventParticipant);
+  const participant = normalizeLiveEventParticipant({ liveEventId: liveEvent.id, hostId: body.hostId, accountId: body.accountId, isLead: body.isLead });
+  const next = participants.filter(function(item) {
+    return !(item.liveEventId === participant.liveEventId && item.hostId === participant.hostId && item.accountId === participant.accountId);
+  });
+  next.push(participant);
+  writeResourceList('liveEventParticipants', next);
+  return { success: true, participant: participant };
+}
+
+function handlePublishLiveEventParticipantLocation(body) {
+  const accountId = String(body.accountId || '');
+  const hostId = String(body.hostId || '');
+  const adm = Boolean(body.isAdm) || isAdmAccount(accountId);
+  if (!adm && !isActiveHostMember(accountId, hostId)) return { error: 'Only host members can publish this host location' };
+  const liveEvents = readResourceList('liveEvents').map(normalizeLiveEvent);
+  if (!liveEvents.some(function(event) { return event.id === body.liveEventId && event.status === 'active'; })) return { error: 'Live event not found' };
+  const participants = readResourceList('liveEventParticipants').map(normalizeLiveEventParticipant);
+  const index = participants.findIndex(function(item) { return item.liveEventId === body.liveEventId && item.hostId === hostId && item.accountId === accountId; });
+  const participant = normalizeLiveEventParticipant(index >= 0 ? participants[index] : { liveEventId: body.liveEventId, hostId: hostId, accountId: accountId });
+  participant.lastLocationAt = new Date().toISOString();
+  participant.speedKmh = Number(body.speedKmh) || 0;
+  participant.isSharingEnabled = body.isSharingEnabled !== false;
+  if (index >= 0) participants[index] = participant; else participants.push(participant);
+  writeResourceList('liveEventParticipants', participants);
+  return { success: true, participant: participant };
 }
 
 function toCamelCase(value) {

--- a/src/services/repository.js
+++ b/src/services/repository.js
@@ -4,13 +4,17 @@ import { loadHosts as loadLocalHosts, saveHosts as saveLocalHosts } from './stor
 const REPORTS_KEY = 'youth-montreal-reports';
 const HOST_REQUESTS_KEY = 'youth-montreal-host-requests';
 const HOST_MEMBERSHIPS_KEY = 'youth-montreal-host-memberships';
+const LIVE_EVENTS_KEY = 'youth-montreal-live-events';
+const LIVE_EVENT_PARTICIPANTS_KEY = 'youth-montreal-live-event-participants';
 const AUDIT_LOG_KEY = 'youth-montreal-audit-log';
 const PENDING_SYNC_KEY = 'youth-montreal-pending-sync';
 const SYNC_URL_KEY = 'youth-montreal-sheets-url';
 const LEGACY_LOCAL_KEYS = {
   [REPORTS_KEY]: ['youth-montreal-suggestions'],
   [HOST_REQUESTS_KEY]: ['youth-montreal-title-requests'],
-  [HOST_MEMBERSHIPS_KEY]: ['youth-montreal-hostMemberships']
+  [HOST_MEMBERSHIPS_KEY]: ['youth-montreal-hostMemberships'],
+  [LIVE_EVENTS_KEY]: ['youth-montreal-liveEvents'],
+  [LIVE_EVENT_PARTICIPANTS_KEY]: ['youth-montreal-liveEventParticipants']
 };
 const syncListeners = new Set();
 const REMOTE_TIMEOUT_MS = 8000;
@@ -175,6 +179,52 @@ function migrateLegacyLocalList(key) {
     return saved;
   }
   return '';
+}
+
+function normalizeLiveEvent(entry = {}) {
+  const now = new Date().toISOString();
+  const titleBase = String(entry.titleBase || entry.title || '').trim();
+  return {
+    id: entry.id || crypto.randomUUID(),
+    title: String(entry.title || titleBase).trim(),
+    titleBase,
+    description: String(entry.description || ''),
+    status: entry.status || 'active',
+    joinCode: String(entry.joinCode || '').trim(),
+    createdByAccountId: String(entry.createdByAccountId || ''),
+    createdByHostId: String(entry.createdByHostId || ''),
+    startedAt: entry.startedAt || now,
+    endedAt: entry.endedAt || '',
+    filters: entry.filters && typeof entry.filters === 'object' ? entry.filters : {}
+  };
+}
+
+function normalizeLiveEventParticipant(entry = {}) {
+  return {
+    liveEventId: String(entry.liveEventId || ''),
+    hostId: String(entry.hostId || ''),
+    accountId: String(entry.accountId || ''),
+    isLead: Boolean(entry.isLead),
+    joinedAt: entry.joinedAt || new Date().toISOString(),
+    lastLocationAt: entry.lastLocationAt || '',
+    speedKmh: Number.isFinite(Number(entry.speedKmh)) ? Number(entry.speedKmh) : 0,
+    isSharingEnabled: entry.isSharingEnabled !== false
+  };
+}
+
+function resolveUniqueLiveEventTitle(titleBase, liveEvents, currentId = '') {
+  const normalizedBase = String(titleBase || '').trim() || 'Live Event';
+  const activeTitles = new Set((liveEvents || [])
+    .filter((event) => event.status === 'active' && event.id !== currentId)
+    .map((event) => String(event.title || '').trim().toLowerCase())
+    .filter(Boolean));
+  let candidate = normalizedBase;
+  let suffix = 2;
+  while (activeTitles.has(candidate.toLowerCase())) {
+    candidate = `${normalizedBase} (${suffix})`;
+    suffix += 1;
+  }
+  return candidate;
 }
 
 function normalizeEntry(entry) {
@@ -354,4 +404,80 @@ export async function exchangeHostAccessCode(accessCode) {
   } catch {
     return null;
   }
+}
+
+
+export async function loadLiveEvents() {
+  return loadList('liveEvents', LIVE_EVENTS_KEY).then((list) => list.map(normalizeLiveEvent));
+}
+
+export async function saveLiveEvents(liveEvents) {
+  await saveList('liveEvents', LIVE_EVENTS_KEY, (liveEvents || []).map(normalizeLiveEvent));
+}
+
+export async function loadLiveEventParticipants() {
+  return loadList('liveEventParticipants', LIVE_EVENT_PARTICIPANTS_KEY).then((list) => list.map(normalizeLiveEventParticipant));
+}
+
+export async function saveLiveEventParticipants(participants) {
+  await saveList('liveEventParticipants', LIVE_EVENT_PARTICIPANTS_KEY, (participants || []).map(normalizeLiveEventParticipant));
+}
+
+export async function createLiveEvent(liveEvent) {
+  if (canAttemptRemote('liveEvents')) {
+    try {
+      const result = await remotePostJson({ action: 'createLiveEvent', liveEvent });
+      if (result?.liveEvent) return normalizeLiveEvent(result.liveEvent);
+    } catch (error) {
+      markPending('liveEvents', await loadLiveEvents(), error instanceof Error ? error.message : String(error));
+    }
+  }
+  const liveEvents = await loadLiveEvents();
+  const nextLiveEvent = normalizeLiveEvent(liveEvent);
+  nextLiveEvent.titleBase = nextLiveEvent.titleBase || nextLiveEvent.title;
+  nextLiveEvent.title = resolveUniqueLiveEventTitle(nextLiveEvent.titleBase, liveEvents, nextLiveEvent.id);
+  liveEvents.push(nextLiveEvent);
+  await saveLiveEvents(liveEvents);
+  return nextLiveEvent;
+}
+
+export async function joinLiveEvent({ liveEventId = '', joinCode = '', hostId = '', accountId = '', isAdm = false, isLead = false }) {
+  if (canAttemptRemote('liveEvents')) {
+    const result = await remotePostJson({ action: 'joinLiveEvent', liveEventId, joinCode, hostId, accountId, isAdm, isLead });
+    if (result?.participant) return normalizeLiveEventParticipant(result.participant);
+    throw new Error(result?.error || 'Unable to join live event');
+  }
+  const liveEvents = await loadLiveEvents();
+  const liveEvent = liveEvents.find((event) => event.id === liveEventId && event.status === 'active');
+  if (!liveEvent) throw new Error('Live event not found');
+  if (!isAdm && liveEvent.joinCode !== String(joinCode || '').trim()) throw new Error('Invalid join code');
+  const participants = await loadLiveEventParticipants();
+  const participant = normalizeLiveEventParticipant({ liveEventId, hostId, accountId, isLead });
+  const next = participants.filter((item) => !(item.liveEventId === liveEventId && item.hostId === hostId && item.accountId === accountId));
+  next.push(participant);
+  await saveLiveEventParticipants(next);
+  return participant;
+}
+
+export async function publishLiveEventParticipantLocation({ liveEventId = '', hostId = '', accountId = '', isAdm = false, latitude, longitude, speedKmh = 0, isSharingEnabled = true }) {
+  if (canAttemptRemote('liveEventParticipants')) {
+    const result = await remotePostJson({ action: 'publishLiveEventParticipantLocation', liveEventId, hostId, accountId, isAdm, latitude, longitude, speedKmh, isSharingEnabled });
+    if (result?.participant) return normalizeLiveEventParticipant(result.participant);
+    throw new Error(result?.error || 'Unable to publish live event location');
+  }
+  const memberships = await loadHostMemberships();
+  const isMember = memberships.some((item) => item.hostId === hostId && item.accountId === accountId && item.status !== 'revoked');
+  if (!isAdm && !isMember) throw new Error('Only host members can publish this host location');
+  const liveEvents = await loadLiveEvents();
+  if (!liveEvents.some((event) => event.id === liveEventId && event.status === 'active')) throw new Error('Live event not found');
+  const participants = await loadLiveEventParticipants();
+  const index = participants.findIndex((item) => item.liveEventId === liveEventId && item.hostId === hostId && item.accountId === accountId);
+  const patch = { lastLocationAt: new Date().toISOString(), latitude: Number(latitude), longitude: Number(longitude), speedKmh: Number(speedKmh) || 0, isSharingEnabled };
+  const participant = normalizeLiveEventParticipant({ ...(participants[index] || { liveEventId, hostId, accountId }), ...patch });
+  participant.latitude = patch.latitude;
+  participant.longitude = patch.longitude;
+  const next = [...participants];
+  if (index >= 0) next[index] = participant; else next.push(participant);
+  await saveLiveEventParticipants(next);
+  return participant;
 }


### PR DESCRIPTION
### Motivation

- Introduce canonical `liveEvent` and `liveEventParticipant` resources so live collaboration (live events and participants) is persisted and validated by the backend. 
- Ensure active live event titles are unique and automatically suffixed when collisions occur so the UI receives the final assigned title. 
- Only allow hosts (or ADMs) to join/publish location for a host in a live event and enforce join-by-code for hosts while allowing ADM bypass for management and diagnostics. 

### Description

- Added local keys, normalization helpers and uniqueness resolution in `src/services/repository.js` and exposed repository APIs: `loadLiveEvents`, `saveLiveEvents`, `loadLiveEventParticipants`, `saveLiveEventParticipants`, `createLiveEvent`, `joinLiveEvent`, and `publishLiveEventParticipantLocation` with remote action fallbacks. 
- Implemented title de-duplication that auto-suffixes active titles (e.g. `Title (2)`) and returns the final assigned `title` to callers during creation. 
- Extended the Apps Script backend in `src/services/google-sheets-backend.gs` to register `liveEvents` and `liveEventParticipants` sheets and added handlers `handleCreateLiveEvent`, `handleJoinLiveEvent`, and `handlePublishLiveEventParticipantLocation` with canonical field normalization, ADM allowlist checks, host-membership checks, and the same uniqueness behavior. 
- Documented the contract and canonical fields in `README.md` under "Live event backend contract" so agents and future developers can follow the sync/validation expectations. 

### Testing

- Ran a syntax check on the web adapter with `node --check src/services/repository.js` which completed successfully. 
- Verified the Apps Script file by copying it to a temporary `.mjs` file and running `node --check` on that temporary file which succeeded; direct `node --check src/services/google-sheets-backend.gs` fails with an expected file-extension error because `.gs` is an Apps Script file, not a native Node file. 
- No automated unit tests were present for these flows in the repository; manual and integration validation is required when deploying the Apps Script backend URL to ensure remote action paths work end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a825d43d80c8333abf3873286e41fb2)